### PR TITLE
Update query-by-id method to accept index as parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+### Changed
+- Updated Elasticsearch *query_by_id* method to accept an *index* as argument
+### Deprecated
+### Removed
+### Fixed
+### Security
+
 ## [0.3.0] - 2022-07-13
 ### Added
 - CDMS-xxx: Added `CLI` script to ingest S3 data into the Parquet system

--- a/parquet_flask/aws/es_abstract.py
+++ b/parquet_flask/aws/es_abstract.py
@@ -58,7 +58,7 @@ class ESAbstract(ABC):
         return
 
     @abstractmethod
-    def query_by_id(self, doc_id):
+    def query_by_id(self, doc_id, index=None):
         return
 
     @abstractmethod

--- a/parquet_flask/aws/es_middleware.py
+++ b/parquet_flask/aws/es_middleware.py
@@ -188,8 +188,8 @@ class ESMiddleware(ESAbstract):
             'items': first_batch['hits']['hits'],
         }
 
-    def query_by_id(self, doc_id):
-        index = self.__validate_index(None)
+    def query_by_id(self, doc_id, index=None):
+        index = self.__validate_index(index)
         dsl = {
             'query': {
                 'term': {'_id': doc_id}

--- a/parquet_flask/io_logic/metadata_tbl_es.py
+++ b/parquet_flask/io_logic/metadata_tbl_es.py
@@ -46,7 +46,7 @@ class MetadataTblES(MetadataTblInterface):
         return
 
     def get_by_s3_url(self, s3_url):
-        result = self.__es.query_by_id(s3_url)
+        result = self.__es.query_by_id(s3_url, CDMSConstants.entry_file_records_index)
         if result is None:
             return None
         return result['_source']


### PR DESCRIPTION
Update query-by-id method to accept index as parameter. This allows precise querying against a specific ES index, instead of against the entire cluster.