### PR TITLE
Indexing Lambda fix

### DIFF
--- a/docker/parquet.lambda.Dockerfile
+++ b/docker/parquet.lambda.Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM public.ecr.aws/lambda/python:3.7
+FROM public.ecr.aws/lambda/python:3.7.2022.09.27.11
 
 # Reference: https://aws.plainenglish.io/spark-on-aws-lambda-c65877c0ac96
 #USER root

--- a/parquet_flask/cdms_lambda_func/index_to_es/parquet_file_es_indexer.py
+++ b/parquet_flask/cdms_lambda_func/index_to_es/parquet_file_es_indexer.py
@@ -90,7 +90,7 @@ class ParquetFileEsIndexer:
             self.__s3_url = s3_records.get_s3_url(i)
             if any([k in self.__s3_url for k in ignoring_phrases]):
                 LOGGER.debug(f'skipping temp file: {self.__s3_url}')
-                return
+                continue
             LOGGER.debug(f'executing: {self.__s3_url}')
             s3_event = s3_records.get_event_name(i).strip().lower()
             if s3_event.startswith('objectcreated'):
@@ -100,5 +100,5 @@ class ParquetFileEsIndexer:
                 LOGGER.debug('executing to remove index')
                 self.remove_file()
             else:
-                raise ValueError(f'invalid s3_event: {s3_event}')
+                LOGGER.error(f'invalid s3_event: {s3_event}; skipping it')
         return

--- a/parquet_flask/cdms_lambda_func/index_to_es/parquet_file_es_indexer.py
+++ b/parquet_flask/cdms_lambda_func/index_to_es/parquet_file_es_indexer.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import json
 
 from parquet_flask.parquet_stat_extractor.local_statistics_retriever import LocalStatisticsRetriever
 from parquet_flask.utils.file_utils import FileUtils
@@ -80,6 +81,9 @@ class ParquetFileEsIndexer:
         #         'match_all': {}
         #     }
         # }))
+
+        LOGGER.debug(f'Triggering event:\n{json.dumps(event, indent=4)}')
+
         s3_records = S3ToSqs(event)
         ignoring_phrases = ['spark-staging', '_temporary']
         for i in range(s3_records.size()):

--- a/parquet_flask/v1/query_data_doms.py
+++ b/parquet_flask/v1/query_data_doms.py
@@ -96,10 +96,10 @@ class IngestParquet(Resource):
             result_set = query.search()
             LOGGER.debug(f'search params: {payload}b')
             page_info = self.__calculate_4_ranges(result_set['total'])
-            result_set['last'] = f'{request.base_url}?{self.__replace_start_from(page_info["last"])}'
-            result_set['first'] = f'{request.base_url}?{self.__replace_start_from(page_info["first"])}'
-            result_set['next'] = f'{request.base_url}?{self.__replace_start_from(page_info["next"])}'
-            result_set['prev'] = f'{request.base_url}?{self.__replace_start_from(page_info["prev"])}'
+            result_set['last'] = f'{request.base_url}?{self.__replace_start_from(page_info["last"])}'.replace('http://', 'https://')
+            result_set['first'] = f'{request.base_url}?{self.__replace_start_from(page_info["first"])}'.replace('http://', 'https://')
+            result_set['next'] = f'{request.base_url}?{self.__replace_start_from(page_info["next"])}'.replace('http://', 'https://')
+            result_set['prev'] = f'{request.base_url}?{self.__replace_start_from(page_info["prev"])}'.replace('http://', 'https://')
             return result_set, 200
         except Exception as e:
             LOGGER.exception(f'failed to query parquet. cause: {str(e)}')

--- a/parquet_flask/v1/query_data_doms_custom_pagination.py
+++ b/parquet_flask/v1/query_data_doms_custom_pagination.py
@@ -73,12 +73,12 @@ class IngestParquet(Resource):
         if 'markerPlatform' in new_args:
             new_args.pop('markerPlatform')
         new_args = '&'.join([f'{k}={v}' for k, v in new_args.items()])
-        return f'{request.base_url}?{new_args}'
+        return f'{request.base_url}?{new_args}'.replace('http://', 'https://')
 
     def __get_prev_page_url(self):
         new_args = deepcopy(dict(request.args))
         new_args = '&'.join([f'{k}={v}' for k, v in new_args.items()])
-        return f'{request.base_url}?{new_args}'
+        return f'{request.base_url}?{new_args}'.replace('http://', 'https://')
 
     def __get_next_page_url(self, query_result: list):
         if len(query_result) < 1:
@@ -88,7 +88,7 @@ class IngestParquet(Resource):
         new_args['markerTime'] = last_item[CDMSConstants.time_col]
         new_args['markerPlatform'] = GeneralUtils.gen_sha_256_json_obj(last_item)
         new_args = '&'.join([f'{k}={v}' for k, v in new_args.items()])
-        return f'{request.base_url}?{new_args}'
+        return f'{request.base_url}?{new_args}'.replace('http://', 'https://')
 
     def __execute_query(self, payload):
         """

--- a/setup_lambda.py
+++ b/setup_lambda.py
@@ -18,12 +18,13 @@ from setuptools import find_packages, setup
 
 install_requires = [
     # 'fastparquet===0.5.0',  # not using it. sticking to pyspark with spark cluster according to Nga
-    'jsonschema',  # to verify json objects
+    'jsonschema==4.16.0',  # to verify json objects
     'fastjsonschema===2.15.1',
     'requests===2.26.0',
     'boto3', 'botocore',
     'requests_aws4auth===1.1.1',  # to send aws signed headers in requests
     'elasticsearch===7.13.4',
+    'typing_extensions==4.3.0'
 ]
 
 setup(


### PR DESCRIPTION
When going through a SQS messages of S3 events, indexer would break the loop when a temp parquet file was encountered. If a valid parquet file event followed in the messages, it would not be processed. We should instead just skip to the next S3 event.